### PR TITLE
feat: Convert packages to ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6052,6 +6052,13 @@
         "which": "bin/which"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -12245,6 +12252,47 @@
         "node": ">= 12"
       }
     },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
+      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -12811,23 +12859,24 @@
     },
     "packages/ui": {
       "name": "@app/ui",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@twind/core": "^1.1.3",
         "lucide-preact": "^0.542.0"
       },
       "devDependencies": {
         "@storybook/addon-coverage": "^2.0.0",
-        "@storybook/addon-docs": "^9.1.5",
-        "@storybook/addon-links": "^9.1.5",
-        "@storybook/preact-vite": "^9.1.5",
+        "@storybook/addon-docs": "^9.1.2",
+        "@storybook/addon-links": "^9.1.2",
+        "@storybook/preact-vite": "^9.1.2",
         "@storybook/test-runner": "^0.23.0",
         "@storybook/testing-library": "^0.2.2",
         "@testing-library/preact": "^3.2.4",
         "@twind/preset-autoprefix": "^1.0.7",
         "@twind/preset-tailwind": "^1.1.4",
         "storybook": "^9.1.2",
-        "vite-plugin-turbosnap": "^1.0.3"
+        "vite-plugin-turbosnap": "^1.0.3",
+        "vite-tsconfig-paths": "^5.1.4"
       }
     },
     "services/static": {
@@ -12849,7 +12898,7 @@
       "name": "@app/web",
       "version": "0.0.1",
       "dependencies": {
-        "@app/ui": "0.0.1",
+        "@app/ui": "0.0.2",
         "@astrojs/preact": "^4.1.0",
         "@faker-js/faker": "^10.0.0",
         "@twind/core": "^1.1.3",

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -1,38 +1,32 @@
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
 import type { StorybookConfig } from "@storybook/preact-vite";
 import { mergeConfig } from "vite";
 import turbosnap from "vite-plugin-turbosnap";
-
-const require = createRequire(import.meta.url);
+import tsconfigPaths from "vite-tsconfig-paths";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.@(ts|tsx)"],
-
-  addons: [
-    getAbsolutePath("@storybook/addon-links"),
-    getAbsolutePath("@storybook/addon-coverage"),
-    getAbsolutePath("@storybook/addon-docs"),
-  ],
-
+  addons: ["@storybook/addon-links", "@storybook/addon-coverage", "@storybook/addon-docs"],
   framework: {
-    name: getAbsolutePath("@storybook/preact-vite"),
+    name: "@storybook/preact-vite",
     options: {},
   },
+  features: {
+    storyStoreV7: true,
+  },
+  builder: "@storybook/builder-vite",
 
   async viteFinal(config, { configType }) {
     const isProduction = configType === "PRODUCTION";
 
     return mergeConfig(config, {
-      plugins: isProduction
-        ? [turbosnap({ rootDir: config.root ?? process.cwd() })]
-        : [],
+      plugins: [
+        tsconfigPaths(),
+        ...(isProduction
+          ? [turbosnap({ rootDir: config.root ?? process.cwd() })]
+          : []),
+      ],
     });
   },
 };
 
 export default config;
-
-function getAbsolutePath(value: string): string {
-  return dirname(require.resolve(join(value, "package.json")));
-}

--- a/packages/ui/src/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/ui/src/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,14 +1,14 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { Breadcrumbs } from "./index";
+import type { Meta, StoryObj } from "@storybook/preact";
+import { Breadcrumbs } from "./index.js";
 
-const meta = {
+const meta: Meta<typeof Breadcrumbs> = {
   title: "Breadcrumbs",
   component: Breadcrumbs,
-} satisfies Meta<typeof Breadcrumbs>;
+};
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Breadcrumbs>;
 
 export const Default: Story = {
   args: {

--- a/packages/ui/src/Breadcrumbs/index.tsx
+++ b/packages/ui/src/Breadcrumbs/index.tsx
@@ -12,22 +12,22 @@ type Props = {
 export const Breadcrumbs = ({ breadcrumbs }: Props) => {
   return (
     <nav aria-label="breadcrumb">
-      <ol className={tw`flex space-x-2`}>
+      <ol className={tw(String.raw`flex space-x-2`)}>
         {breadcrumbs.map((breadcrumb, index) => (
           <li
             key={`${breadcrumb.label}-${breadcrumb.href}`}
-            className={tw`flex items-center`}
+            className={tw(String.raw`flex items-center`)}
           >
-            {index > 0 && <span className={tw`mx-2`}>/</span>}
+            {index > 0 && <span className={tw(String.raw`mx-2`)}>/</span>}
             {breadcrumb.href ? (
               <a
                 href={breadcrumb.href}
-                className={tw`text-blue-600 hover:underline`}
+                className={tw(String.raw`text-blue-600 hover:underline`)}
               >
                 {breadcrumb.label}
               </a>
             ) : (
-              <span className={tw`text-gray-500`}>{breadcrumb.label}</span>
+              <span className={tw(String.raw`text-gray-500`)}>{breadcrumb.label}</span>
             )}
           </li>
         ))}

--- a/packages/ui/src/Button/Button.stories.tsx
+++ b/packages/ui/src/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/preact-vite";
-import Button from "./";
+import type { Meta, StoryObj } from "@storybook/preact";
+import Button from "./index.js";
 
 const meta: Meta<typeof Button> = {
   component: Button,

--- a/packages/ui/src/Card/Card.stories.tsx
+++ b/packages/ui/src/Card/Card.stories.tsx
@@ -1,6 +1,6 @@
-import type { Meta, StoryObj } from "@storybook/preact-vite";
-import type { CardProps } from "./";
-import Card from "./";
+import type { Meta, StoryObj } from "@storybook/preact";
+import type { CardProps } from "./index.js";
+import Card from "./index.js";
 
 const meta: Meta<typeof Card> = {
   component: Card,

--- a/packages/ui/src/Footer/Footer.stories.tsx
+++ b/packages/ui/src/Footer/Footer.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/preact-vite";
-import Footer from "./";
+import type { Meta, StoryObj } from "@storybook/preact";
+import Footer from "./index.js";
 
 const meta: Meta<typeof Footer> = {
   component: Footer,

--- a/packages/ui/src/Header/Header.stories.tsx
+++ b/packages/ui/src/Header/Header.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/preact-vite";
-import Header from "./";
+import Header from "./index.js";
 
 const meta: Meta<typeof Header> = {
   component: Header,
@@ -7,4 +7,8 @@ const meta: Meta<typeof Header> = {
 
 export default meta;
 
-export const Basic: StoryObj<typeof Header> = {};
+export const Basic: StoryObj<typeof Header> = {
+  args: {
+    active: "Home",
+  },
+};

--- a/packages/ui/src/LoginForm/LoginForm.stories.tsx
+++ b/packages/ui/src/LoginForm/LoginForm.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/preact";
-import { LoginForm } from "./LoginForm";
+import { LoginForm } from "./LoginForm.js";
 
 const meta = {
   component: LoginForm,

--- a/packages/ui/src/LoginForm/LoginForm.tsx
+++ b/packages/ui/src/LoginForm/LoginForm.tsx
@@ -3,10 +3,10 @@ import type { FunctionComponent } from "preact";
 
 export const LoginForm: FunctionComponent = () => {
   return (
-    <div class={tw`bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4`}>
-      <div class={tw`mb-4`}>
+    <div class={tw(String.raw`bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4`)}>
+      <div class={tw(String.raw`mb-4`)}>
         <button
-          class={tw`bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded w-full focus:outline-none focus:shadow-outline`}
+          class={tw(String.raw`bg-gray-800 hover:bg-gray-900 text-white font-bold py-2 px-4 rounded w-full focus:outline-none focus:shadow-outline`)}
           type="button"
         >
           Sign in with GitHub

--- a/packages/ui/src/LoginForm/index.tsx
+++ b/packages/ui/src/LoginForm/index.tsx
@@ -1,1 +1,1 @@
-export * from "./LoginForm";
+export * from "./LoginForm.js";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,8 @@
+export { Breadcrumbs } from "./Breadcrumbs/index.js";
+export type { Breadcrumb } from "./Breadcrumbs/index.js";
+export { default as Button } from "./Button/index.js";
+export { default as Card } from "./Card/index.js";
+export type { CardProps } from "./Card/index.js";
+export { default as Footer } from "./Footer/index.js";
+export { default as Header } from "./Header/index.js";
+export * from "./LoginForm/index.js";

--- a/packages/ui/src/twind.d.ts
+++ b/packages/ui/src/twind.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@twind/core" />

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -2,9 +2,12 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "module": "NodeNext",
+    "declaration": true,
+    "allowSyntheticDefaultImports": true
   },
-  "include": ["src"],
-  "exclude": ["**/*.test.ts", "*.stories.tsx"],
+  "include": ["src", "src/twind.d.ts"],
+  "exclude": ["**/*.test.ts", "*.stories.tsx", "lib"],
   "references": []
 }

--- a/services/web/astro.config.mjs
+++ b/services/web/astro.config.mjs
@@ -3,4 +3,12 @@ import { defineConfig } from "astro/config";
 // https://astro.build/config
 export default defineConfig({
   integrations: [preact()],
+  vite: {
+    optimizeDeps: {
+      include: ["@app/ui"],
+    },
+    resolve: {
+      preserveSymlinks: true,
+    },
+  },
 });

--- a/services/web/package.json
+++ b/services/web/package.json
@@ -2,6 +2,7 @@
   "name": "@app/web",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",
     "dev": "astro dev",

--- a/services/web/src/layouts/MainLayout.astro
+++ b/services/web/src/layouts/MainLayout.astro
@@ -1,5 +1,5 @@
 ---
-import Header from "@app/ui/src/Header";
+import { Header } from "@app/ui";
 import TwindSetup from "../components/TwindSetup.astro";
 
 interface Props {

--- a/services/web/src/pages/index.astro
+++ b/services/web/src/pages/index.astro
@@ -1,7 +1,5 @@
 ---
-import { Breadcrumbs } from "@app/ui/src/Breadcrumbs";
-import Card from "@app/ui/src/Card";
-import type { CardProps } from "@app/ui/src/Card";
+import { Breadcrumbs, Card, type CardProps } from "@app/ui";
 import MainLayout from "../layouts/MainLayout.astro";
 import { faker } from "@faker-js/faker";
 

--- a/services/web/src/pages/login.astro
+++ b/services/web/src/pages/login.astro
@@ -1,6 +1,5 @@
 ---
-import Header from "@app/ui/src/Header";
-import { LoginForm } from "@app/ui/src/LoginForm";
+import { Header, LoginForm } from "@app/ui";
 import TwindSetup from "../components/TwindSetup.astro";
 ---
 


### PR DESCRIPTION
This commit migrates the `@app/ui` package to be a full ES Module and configures the consuming `services/web` package accordingly.

Key changes include:
- Updated `packages/ui/package.json` with `"type": "module"` and an `exports` map.
- Configured `packages/ui/tsconfig.json` to output ESM (`"module": "NodeNext"`).
- Created a main entry point `packages/ui/src/index.ts` to provide a clear public API.
- Updated all internal and external imports to be compatible with ESM module resolution.
- Added `"type": "module"` to `services/web/package.json`.
- Added Vite configuration to `services/web/astro.config.mjs` to aid in resolving the local ESM package.
- Fixed various TypeScript, Storybook, and `twind` typing issues that arose during the conversion.

Known Issues:
- The build for `services/web` is still failing due to a module resolution issue with Vite and the local ESM package. The applied configuration changes did not resolve this.
- The Storybook test for the `Header` component in `@app/ui` fails due to a persistent Preact rendering error in the test runner environment.