### PR TITLE
feat: Configure Codecov test results action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -48,6 +48,14 @@ jobs:
             "npx http-server packages/ui/storybook-static --port 6006 --silent" \
             "npx wait-on tcp:6006 && npm test"
 
+      - name: Upload test results to Codecov
+        uses: codecov/test-results-action@v1
+        if: always()
+        with:
+          files: ./services/web/junit.xml,./packages/ui/junit.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -154,4 +154,6 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+# Test results
+**/junit.xml
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc --build .",
     "prepack": "npm run build",
-    "test": "test-storybook --coverage",
+    "test": "test-storybook --coverage --junit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "posttest": "cp coverage/storybook/coverage-storybook.json coverage/coverage-storybook.json && nyc report --reporter=lcov -t coverage --report-dir coverage"

--- a/services/web/vitest.config.ts
+++ b/services/web/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   root: path.resolve(__dirname, "../../"),
   plugins: [preact()],
   test: {
+    reporters: [["junit", { outputFile: "services/web/junit.xml" }]],
     environment: "happy-dom",
     globals: true,
     setupFiles: "services/web/src/tests/setup.ts",


### PR DESCRIPTION
This commit configures the `codecov/test-results-action` to upload test reports to Codecov for analysis.

- Modifies the vitest config for `services/web` to generate a JUnit report.
- Adds the `--junit` flag to the `test-storybook` command for `packages/ui` to generate a JUnit report.
- Adds a new step to the `node.js.yml` workflow to upload the generated JUnit reports from both workspaces.
- Updates `.gitignore` to exclude the generated JUnit XML files.